### PR TITLE
Use JSON#parse with symbolize_names: true instead of HashWithIndifferentAccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ describe Api::V1::UsersController, type: :api
     end
 
     it 'returns the data in the body' do
-      body = HashWithIndifferentAccess.new(MultiJson.load(last_response.body))
+      body = JSON.parse(last_response.body, symbolize_names: true)
       expect(body.dig(:data, :attributes, :name).to eql(@user.name)
       expect(body.dig(:data, :attributes, :email).to eql(@user.name)
       expect(body.dig(:data, :attributes, :admin).to eql(@user.admin)


### PR DESCRIPTION
Congradurations on getting at the top of this week's Ruby Weekly! However, I see a lot of suggestions that should not be made.

* Use of MultiJson shouldn't be encouraged: https://github.com/intridea/multi_json/pull/113#issuecomment-17668823
* If you'd like to use symbol keys, you can just use `JSON.parse(last_response.body, symbolize_names: true)` rather than using `HashWithIndifferentAccess`

I'll send more as I find something that should be fixed.